### PR TITLE
Fix segfault with optional groups

### DIFF
--- a/cffi_re2/__init__.py
+++ b/cffi_re2/__init__.py
@@ -74,6 +74,8 @@ class MatchObject(object):
 
     def group(self, i):
         start, end = self.ranges[i]
+        if start == end == -1:
+            return None
         return self.string[start:end]
 
     def groups(self):

--- a/cffi_re2/__init__.py
+++ b/cffi_re2/__init__.py
@@ -74,7 +74,7 @@ class MatchObject(object):
 
     def group(self, i):
         start, end = self.ranges[i]
-        if start == end == -1:
+        if start == -1 or end == -1:
             return None
         return self.string[start:end]
 

--- a/cre2.cpp
+++ b/cre2.cpp
@@ -176,6 +176,11 @@ extern "C" {
             //Copy range
             Range* rangeTmp = new Range[ret.numElements];
             for (int i = 0; i < ret.numElements; ++i) {
+                if(matchTmp[i].data() == NULL) {
+                    rangeTmp[i].start = -1;
+                    rangeTmp[i].end = -1;
+                    continue;
+                }
                 int rawStart = matchTmp[i].data() - dataArg;
                 rangeTmp[i].start = utf8LUT[rawStart];
                 rangeTmp[i].end = utf8LUT[rawStart + matchTmp[i].size()];

--- a/cre2.cpp
+++ b/cre2.cpp
@@ -55,7 +55,7 @@ typedef struct {
  * @return a new[]-allocated int array of size len, containing the LUT
  */
 int* buildUTF8IndexLUT(const char* s, size_t len) {
-    int* lut = new int[len];
+    int* lut = new int[len + 1];
     int sidx = 0; // Index in the LUT
     for(unsigned int i = 0 ; i < len ; i++) { // i = Current index in s
         if((s[i] & 0x80) == 0) { //Single-byte character
@@ -73,6 +73,9 @@ int* buildUTF8IndexLUT(const char* s, size_t len) {
             sidx++;
         }
     }
+    //Last entry is relevant when a group ends at the end of the string.
+    // This behaviour leverages Python slicing automatically limiting the end index
+    lut[len] = len;
     return lut;
 }
 

--- a/cre2.cpp
+++ b/cre2.cpp
@@ -216,6 +216,11 @@ extern "C" {
             //Copy ranges
             ret.ranges = new Range[ret.numGroups];
             for (int i = 0; i < ret.numGroups; ++i) {
+                if(groups[i].data() == NULL) {
+                    ret.ranges[i].start = -1;
+                    ret.ranges[i].end = -1;
+                    continue;
+                }
                 int rawStart = groups[i].data() - dataArg;
                 ret.ranges[i].start = utf8LUT[rawStart];
                 ret.ranges[i].end = utf8LUT[rawStart + groups[i].size()];

--- a/tests/TestBasicRegex.py
+++ b/tests/TestBasicRegex.py
@@ -136,6 +136,7 @@ class TestBasicRegex(object):
 
     def test_more_x(self):
         assert_is_none(cffi_re2.search(r"<(a|span|div|table)", "Kapazitäten"))
+        assert_equal(cffi_re2.findall(r"<(a|span|div|table)", "Kapazitäten"), [])
 
     def test_optional_groups(self):
         result = cffi_re2.search(r"(foo)?bar", "bar")

--- a/tests/TestBasicRegex.py
+++ b/tests/TestBasicRegex.py
@@ -134,6 +134,11 @@ class TestBasicRegex(object):
         assert_is_none(cffi_re2.match(r'b+', 'abbcbbd'))
         assert_is_not_none(cffi_re2.match(r'b+', 'bbbbb'))
 
+    def test_optional_groups(self):
+        result = cffi_re2.search(r"(foo)?bar", "bar")
+        assert_equal(result.group(0), "bar")
+        assert_is_none(result.group(1))
+
 
 class TestFlags(object):
     def test_flag_ignorecase(self):

--- a/tests/TestBasicRegex.py
+++ b/tests/TestBasicRegex.py
@@ -139,6 +139,9 @@ class TestBasicRegex(object):
         assert_equal(cffi_re2.findall(r"<(a|span|div|table)", "Kapazitäten"), [])
 
     def test_optional_groups(self):
+        assert_equal(cffi_re2.findall(r"(foo)?bar", "bar"), [''])
+
+    def test_optional_groups(self):
         result = cffi_re2.search(r"(foo)?bar", "bar")
         print(result.ranges)
         assert_equal(result.group(0), "bar")

--- a/tests/TestBasicRegex.py
+++ b/tests/TestBasicRegex.py
@@ -134,10 +134,16 @@ class TestBasicRegex(object):
         assert_is_none(cffi_re2.match(r'b+', 'abbcbbd'))
         assert_is_not_none(cffi_re2.match(r'b+', 'bbbbb'))
 
+    def test_more_x(self):
+        assert_is_none(cffi_re2.search(r"<(a|span|div|table)", "Kapazitäten"))
+
     def test_optional_groups(self):
         result = cffi_re2.search(r"(foo)?bar", "bar")
+        print(result.ranges)
         assert_equal(result.group(0), "bar")
         assert_is_none(result.group(1))
+        assert_equal(result.groups(), (None,))
+
 
 
 class TestFlags(object):


### PR DESCRIPTION
Optional subgroups caused wrong NULL pointer arithmetic. This PR fixes this and adds regression tests.
